### PR TITLE
feat: use `with_connection` where possible

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/module/attribute_accessors'
 
+require_relative './with_connection'
+
 module CounterCulture
   class Reconciler
     ACTIVE_RECORD_VERSION = Gem.loaded_specs["activerecord"].version
@@ -312,7 +314,9 @@ module CounterCulture
       # using Postgres with schema-namespaced tables. But then it's required,
       # and otherwise it's just a no-op, so why not do it?
       def quote_table_name(table_name)
-        relation_class.connection.quote_table_name(table_name)
+        WithConnection.new(relation_class).call do |connection|
+          connection.quote_table_name(table_name)
+        end
       end
 
       def parameterize(string)

--- a/lib/counter_culture/with_connection.rb
+++ b/lib/counter_culture/with_connection.rb
@@ -1,0 +1,33 @@
+module CounterCulture
+  class WithConnection
+    def initialize(recipient)
+      @recipient = recipient
+    end
+
+    attr_reader :recipient
+
+    def call
+      if rails_7_2_or_greater?
+        recipient.with_connection do |connection|
+          yield connection
+        end
+      elsif rails_7_1?
+        recipient.connection_pool.with_connection do |connection|
+          yield connection
+        end
+      else
+        yield recipient.connection
+      end
+    end
+
+    private
+
+    def rails_7_1?
+      Gem::Requirement.new('~> 7.1.0').satisfied_by?(Gem::Version.new(Rails.version))
+    end
+
+    def rails_7_2_or_greater?
+      Gem::Requirement.new('>= 7.2.0').satisfied_by?(Gem::Version.new(Rails.version))
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/rails/rails/pull/51349 - this allows rails 7.2 applications to raise an error or emit a deprecation warning whenever `ActiveRecord::Base.connection` is used.

this makes sure that in rails 7.1 and after we use the new, preferred method.